### PR TITLE
アカウント情報編集画面の実装

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -151,3 +151,40 @@ a{
 .avatar-full{
   width: 100%;
 }
+
+//Forms
+.form-group{
+  margin-bottom: 25px;
+}
+
+.form-control{
+  border-radius: 2px;
+  height: 4rem;
+}
+
+//Sidebar
+.sidebar-list{
+  padding-left: 0;
+  list-style: none;
+}
+.sidebar-item{
+  padding: 10px 0;
+  font-size: 16px;
+  color: #82888a;
+}
+
+.sidebar-link{
+  color: #82888a;
+  text-decoration: none;
+}
+
+.sidebar-link:hover, .sidebar-link:focus{
+  color: #caaaad;
+  text-decoration: none;
+}
+
+.active.sidebar-link{
+  color: #565a5c;
+  font-weight: bold;
+  text-decoration: none;
+}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,6 +7,6 @@ class ApplicationController < ActionController::Base
 
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:sign_up, keys: [:fullname])
-    devise_parameter_sanitizer.permit(:account_update, keys: [:fullname])
+    devise_parameter_sanitizer.permit(:account_update, keys: [:fullname,:phone_number, :description])
   end
 end

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -1,0 +1,6 @@
+class RegistrationsController < Devise::RegistrationsController
+  protected
+    def update_resource(resource, params)
+      resource.update_without_password(params)
+    end
+end

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,38 +1,54 @@
 <div class="row">
-  <div class="col-md-6 offset-md-3 text-center">
-    <h2>プロフィール</h2>
+  <div class="col-md-3">
+    <ul class="sidebar-list">
+      <li class="sidebar-item">
+        <%= link_to "プロフィールを編集する", edit_user_registration_path, class: "sidebar-link active" %>
+      </li>
+    </ul>
+    <%= link_to "マイプロフィール", user_path(current_user.id), class: "btn btn-default" %>
+  </div>
+  <div class="col-md-9 text-center">
+    <div class="card">
+      <div class="card-header">ユーザー情報</div>
+      <div class="card-body">
+        <div class="container">
+          <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
+            <%= render "shared/deviseErrorMsg" %>
 
-    <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
-      <%= render "shared/deviseErrorMsg" %>
+            <div class="form-group">
+              <%= f.text_field :fullname, class: "form-control", placeholder: 'フルネーム', autofocus: true, autocomplete: "email" %>
+            </div>
 
-      <div class="form-group">
-        <%= f.text_field :fullname, class: "form-control", placeholder: 'フルネーム', autofocus: true, autocomplete: "email" %>
+            <div class="form-group">
+              <%= f.text_field :phone_number, class: "form-control", placeholder: '電話番号', autofocus: true, autocomplete: "email" %>
+            </div>
+
+            <div class="form-group">
+              <%= f.text_area :description, rows: 5, cols: 25, class: "form-control", placeholder: '自己紹介', autofocus: true, autocomplete: "email" %>
+            </div>
+
+            <div class="form-group">
+              <%= f.email_field :email, class: "form-control", placeholder: 'Emailアドレス', autofocus: true, autocomplete: "email" %>
+            </div>
+
+            <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
+              <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
+            <% end %>
+
+            <div class="form-group">
+              <%= f.password_field :password, class: "form-control", placeholder: '新しいパスワード', autocomplete: "off" %>
+            </div>
+        
+            <div class="form-group">
+              <%= f.password_field :password_confirmation, class: "form-control", placeholder: '確認のためもう一度パスワードを入力してください', autocomplete: "off" %>
+            </div>
+
+            <div class="actions">
+              <%= f.submit "保存",class: "btn btn-normal btn-block" %>
+            </div>
+          <% end %>
+        </div>
       </div>
-
-      <div class="form-group">
-        <%= f.email_field :email, class: "form-control", placeholder: 'Emailアドレス', autofocus: true, autocomplete: "email" %>
-      </div>
-
-      <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
-        <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
-      <% end %>
-
-      <div class="form-group">
-        <%= f.password_field :password, class: "form-control", placeholder: '新しいパスワード', autocomplete: "off" %>
-      </div>
-  
-      <div class="form-group">
-        <%= f.password_field :password_confirmation, class: "form-control", placeholder: '確認のためもう一度パスワードを入力してください', autocomplete: "off" %>
-      </div>
-
-      <div class="form-group">
-        <%= f.password_field :current_password, class: "form-control", placeholder: '現在のパスワード', autocomplete: "off" %>
-      </div>
-
-      <div class="actions">
-        <%= f.submit "保存",class: "btn btn-normal btn-block" %>
-      </div>
-    <% end %>
+    </div>
   </div>
 </div>
-

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -15,7 +15,7 @@
       <% else %>
         <li class="nav-link dropdown">
             <a class="nav-link dropdown-toggle" href="#" id="dropdown01" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-              <%=image_tag avatar_url(current_user), class: "rounded-circle avatar_small" %>&nbsp;
+              <%=image_tag avatar_url(current_user), class: "rounded-circle avatar-small" %>&nbsp;
               <%=current_user.fullname %>
             </a>
             <div class="dropdown-menu" aria-labelledby="dropdown01">

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -2,10 +2,10 @@
   <div class="col-md-3">
     <div class="card">
       <%= image_tag avatar_url(@user), class: "avatar-full card-img-top" %>
-      <h5 class="card-header text-center">Verification</h5>
+      <h5 class="card-header text-center">ユーザー情報</h5>
       <div class="card-body">
-        <p class="card-text">Email Address: <br>
-        Phone Number: </p>
+        <p class="card-text">Email アドレス: <br>
+        電話番号: </p>
       </div>
     </div>
     

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,9 @@
 Rails.application.routes.draw do
   root 'pages#home'
-  devise_for :users, controllers: {omniauth_callbacks: 'users/omniauth_callbacks'},
-            path: '',
-            path_names: {sign_in: 'login', sign_out: 'logout', edit: 'profile', sign_up: 'registration'}
+  devise_for :users, 
+              controllers: {omniauth_callbacks: 'users/omniauth_callbacks', registrations: 'registrations'},
+              path: '',
+              path_names: {sign_in: 'login', sign_out: 'logout', edit: 'profile', sign_up: 'registration'}
 
   resources :users, only: [:show]
             


### PR DESCRIPTION
# WHAT
・アカウント情報編集画面で現在のパスワードを入力しなくても、編集を可能とする。

# WHY
UX向上のため